### PR TITLE
Feature/fix search

### DIFF
--- a/src/main/java/com/interview_master/common/constant/Constant.java
+++ b/src/main/java/com/interview_master/common/constant/Constant.java
@@ -17,5 +17,6 @@ public class Constant {
   public static final String SORT_LATEST = "createdAt";
 
   public static final String SORT_LOWACCURACY = "accuracy";
+  public static final String SORT_MOSTLIKED = "liked";
 
 }

--- a/src/main/java/com/interview_master/dto/CollectionWithAttempt.java
+++ b/src/main/java/com/interview_master/dto/CollectionWithAttempt.java
@@ -20,9 +20,11 @@ public class CollectionWithAttempt {
   private int recentCorrectAttempts;
 
   // CollectionRepositoryImpl에서 필요한 생성자
-  public CollectionWithAttempt(Collection collection, int quizCount, int recentAttempts, int recentCorrectAttempts) {
+  public CollectionWithAttempt(Collection collection, int quizCount, Integer totalAttempts, Integer totalCorrectAttempts, Integer recentAttempts, Integer recentCorrectAttempts) {
     this.collection = collection;
     this.quizCount = quizCount;
+    this.totalAttempts = totalAttempts != null ? totalAttempts : 0;
+    this.totalCorrectAttempts = totalCorrectAttempts != null ? totalCorrectAttempts : 0;
     this.recentAttempts = recentAttempts;
     this.recentCorrectAttempts = recentCorrectAttempts;
   }

--- a/src/main/java/com/interview_master/dto/SortOrder.java
+++ b/src/main/java/com/interview_master/dto/SortOrder.java
@@ -2,5 +2,6 @@ package com.interview_master.dto;
 
 public enum SortOrder {
   LATEST,
-  LOWEST_ACCURACY
+  LOWEST_ACCURACY,
+  MOST_LIKED
 }

--- a/src/main/java/com/interview_master/infrastructure/CollectionRepository.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepository.java
@@ -49,6 +49,6 @@ public interface CollectionRepository extends Repository<Collection, Long>, Coll
       @Param("access") Access access, Pageable pageable);
 
   @Override
-  Page<CollectionWithAttempt> searchCollections(List<Long> categoryIds, List<String> keywords,
+  Page<CollectionWithAttempt> searchCollectionsForAuthUser(List<Long> categoryIds, List<String> keywords,
       Integer maxCorrectRate, Pageable pageable, Long userId);
 }

--- a/src/main/java/com/interview_master/infrastructure/CollectionRepositoryCustom.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface CollectionRepositoryCustom {
 
-  Page<CollectionWithAttempt> searchCollections(List<Long> categoryIds,
+  Page<CollectionWithAttempt> searchCollectionsForAuthUser(List<Long> categoryIds,
       List<String> keywords,
       Integer maxCorrectRate, Pageable pageable, Long userId);
 

--- a/src/main/java/com/interview_master/infrastructure/CollectionRepositoryCustom.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepositoryCustom.java
@@ -11,4 +11,7 @@ public interface CollectionRepositoryCustom {
       List<String> keywords,
       Integer maxCorrectRate, Pageable pageable, Long userId);
 
+  Page<CollectionWithAttempt> searchCollectionsForGuest(List<Long> categoryIds,
+      List<String> keywords, Pageable pageable);
+
 }

--- a/src/main/java/com/interview_master/infrastructure/CollectionRepositoryImpl.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.interview_master.infrastructure;
 
+import static com.interview_master.common.constant.Constant.SORT_LOWACCURACY;
+import static com.interview_master.common.constant.Constant.SORT_MOSTLIKED;
 import static com.interview_master.domain.collection.QCollection.collection;
 import static com.interview_master.domain.usercollectionattempt.QUserCollectionAttempt.userCollectionAttempt;
 
@@ -164,16 +166,21 @@ public class CollectionRepositoryImpl implements CollectionRepositoryCustom {
     query.where(whereClause);
 
     // LOWEST_ACCURACY sorting
-    if (pageable.getSort().getOrderFor("accuracy") != null) {
+    if (pageable.getSort().getOrderFor(SORT_LOWACCURACY) != null) {
       accuracyExpression =
           recentAttempt.correctQuizCount.multiply(100)
               .divide(recentAttempt.totalQuizCount.coalesce(1));
 
-      if (pageable.getSort().getOrderFor("accuracy").isAscending()) {
+      if (pageable.getSort().getOrderFor(SORT_LOWACCURACY).isAscending()) {
         query.orderBy(accuracyExpression.asc());
       } else {
         query.orderBy(accuracyExpression.desc());
       }
+    } else if (pageable.getSort().getOrderFor(SORT_MOSTLIKED) != null) {
+      query.orderBy(
+          collection.likes.desc(),
+          collection.createdAt.desc()
+      );
     } else {
       // LATEST sorting
       query.orderBy(collection.createdAt.desc());

--- a/src/main/java/com/interview_master/infrastructure/CollectionRepositoryImpl.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepositoryImpl.java
@@ -3,11 +3,12 @@ package com.interview_master.infrastructure;
 import static com.interview_master.domain.collection.QCollection.collection;
 import static com.interview_master.domain.usercollectionattempt.QUserCollectionAttempt.userCollectionAttempt;
 
+import com.interview_master.common.exception.ApiException;
+import com.interview_master.common.exception.ErrorCode;
 import com.interview_master.domain.Access;
 import com.interview_master.dto.CollectionWithAttempt;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.JPQLQuery;
@@ -29,8 +30,12 @@ public class CollectionRepositoryImpl implements CollectionRepositoryCustom {
   }
 
   @Override
-  public Page<CollectionWithAttempt> searchCollections(List<Long> categoryIds,
+  public Page<CollectionWithAttempt> searchCollectionsForAuthUser(List<Long> categoryIds,
       List<String> keywords, Integer maxCorrectRate, Pageable pageable, Long userId) {
+    if (userId == null) {
+      throw new ApiException(ErrorCode.AUTHORIZATION_TOKEN_NOT_FOUND);
+    }
+
     BooleanBuilder whereClause = new BooleanBuilder();
 
     whereClause.and(collection.isDeleted.eq(false));
@@ -52,54 +57,43 @@ public class CollectionRepositoryImpl implements CollectionRepositoryCustom {
 
     JPQLQuery<CollectionWithAttempt> query;
 
-    if (userId != null) {
-      // 로그인한 사용자를 위한 쿼리
-      query = queryFactory
-          .select(Projections.constructor(CollectionWithAttempt.class,
-              collection,
-              collection.quizzes.size(),
-              userCollectionAttempt.totalQuizCount,
-              userCollectionAttempt.correctQuizCount))
-          .from(collection)
-          .leftJoin(userCollectionAttempt)
-          .on(userCollectionAttempt.collection.eq(collection)
-              .and(userCollectionAttempt.user.id.eq(userId))
-              .and(userCollectionAttempt.completedAt.isNotNull())
-              .and(userCollectionAttempt.completedAt.eq(
-                  JPAExpressions.select(userCollectionAttempt.completedAt.max())
-                      .from(userCollectionAttempt)
-                      .where(userCollectionAttempt.collection.eq(collection)
-                          .and(userCollectionAttempt.user.id.eq(userId))
-                          .and(userCollectionAttempt.completedAt.isNotNull()))
-              )))
-          .where(collection.access.eq(Access.PUBLIC).or(collection.creator.id.eq(userId)));
+    query = queryFactory
+        .select(Projections.constructor(CollectionWithAttempt.class,
+            collection,
+            collection.quizzes.size(),
+            userCollectionAttempt.totalQuizCount,
+            userCollectionAttempt.correctQuizCount))
+        .from(collection)
+        .leftJoin(userCollectionAttempt)
+        .on(userCollectionAttempt.collection.eq(collection)
+            .and(userCollectionAttempt.user.id.eq(userId))
+            .and(userCollectionAttempt.completedAt.isNotNull())
+            .and(userCollectionAttempt.completedAt.eq(
+                JPAExpressions.select(userCollectionAttempt.completedAt.max())
+                    .from(userCollectionAttempt)
+                    .where(userCollectionAttempt.collection.eq(collection)
+                        .and(userCollectionAttempt.user.id.eq(userId))
+                        .and(userCollectionAttempt.completedAt.isNotNull()))
+            )))
+        .where(collection.access.eq(Access.PUBLIC).or(collection.creator.id.eq(userId)));
 
-      // Max correct rate (로그인 사용자에게만 적용)
-      NumberExpression<Integer> accuracyExpression = userCollectionAttempt.correctQuizCount
-          .multiply(100.0)
-          .divide(userCollectionAttempt.totalQuizCount.coalesce(1));
+    // Max correct rate (정답률 x% 이하 조건)
+    NumberExpression<Integer> accuracyExpression = userCollectionAttempt.correctQuizCount
+        .multiply(100.0)
+        .divide(userCollectionAttempt.totalQuizCount.coalesce(1));
 
-      if (maxCorrectRate != null) {
-        whereClause.and(userCollectionAttempt.totalQuizCount.gt(0)
-            .and(accuracyExpression.loe(maxCorrectRate)));
-      }
-    } else {
-      // 비로그인 사용자를 위한 쿼리
-      query = queryFactory
-          .select(Projections.constructor(CollectionWithAttempt.class,
-              collection,
-              collection.quizzes.size(),
-              Expressions.constant(0),
-              Expressions.constant(0)))
-          .from(collection)
-          .where(collection.access.eq(Access.PUBLIC));
+    if (maxCorrectRate != null) {
+      whereClause
+          .and(userCollectionAttempt.completedAt.isNotNull()) // 정상적으로 완료되고
+          .and(userCollectionAttempt.totalQuizCount.gt(0) // 실제 문제 풀었던 기록에 대해서
+              .and(accuracyExpression.loe(maxCorrectRate)));
     }
 
     query.where(whereClause);
 
-    if (userId != null && pageable.getSort().getOrderFor("accuracy") != null) {
-      // LOWEST_ACCURACY sorting (로그인 사용자에게만 적용)
-      NumberExpression<Integer> accuracyExpression =
+    // LOWEST_ACCURACY sorting
+    if (pageable.getSort().getOrderFor("accuracy") != null) {
+      accuracyExpression =
           userCollectionAttempt.correctQuizCount.multiply(100)
               .divide(userCollectionAttempt.totalQuizCount.coalesce(1));
 

--- a/src/main/java/com/interview_master/resolver/SearchCollectionResolver.java
+++ b/src/main/java/com/interview_master/resolver/SearchCollectionResolver.java
@@ -22,13 +22,31 @@ public class SearchCollectionResolver {
   private final SearchCollectionService searchCollectionService;
 
   @QueryMapping
-  public CollectionWithAttemptsPaging searchCollections(
+  public CollectionWithAttemptsPaging searchCollectionsForAuthUser(
       @Argument List<Long> categoryIds, @Argument List<String> keywords,
       @Argument Integer maxCorrectRate, @Argument DataPage paging,
       @Argument SortOrder sort, @ContextValue(required = false) Long userId) {
 
-    Page<CollectionWithAttempt> result = searchCollectionService.searchCollections(
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForAuthUser(
         categoryIds, keywords, maxCorrectRate, paging, sort, userId);
+
+    return CollectionWithAttemptsPaging.builder()
+        .collectionsWithAttempt(result.getContent())
+        .pageInfo(PageInfo.builder()
+            .currentPage(result.getNumber() + 1)
+            .hasNextPage(result.hasNext())
+            .totalPages(result.getTotalPages())
+            .build())
+        .build();
+  }
+
+  @QueryMapping
+  public CollectionWithAttemptsPaging searchCollectionsForGuest(
+      @Argument List<Long> categoryIds, @Argument List<String> keywords,
+      @Argument DataPage paging) {
+
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForGuest(
+        categoryIds, keywords, paging);
 
     return CollectionWithAttemptsPaging.builder()
         .collectionsWithAttempt(result.getContent())

--- a/src/main/java/com/interview_master/service/SearchCollectionService.java
+++ b/src/main/java/com/interview_master/service/SearchCollectionService.java
@@ -21,7 +21,7 @@ public class SearchCollectionService {
   private final CollectionRepository collectionRepository;
   private final CategoryService categoryService;
 
-  public Page<CollectionWithAttempt> searchCollections(
+  public Page<CollectionWithAttempt> searchCollectionsForAuthUser(
       List<Long> categoryIds, List<String> keywords, Integer maxCorrectRate, DataPage paging,
       SortOrder sortOrder, Long userId) {
     // categoryIds 있으면 검증
@@ -34,5 +34,15 @@ public class SearchCollectionService {
 
     return collectionRepository.searchCollectionsForAuthUser(
         categoryIds, keywords, maxCorrectRate, pageable, userId);
+  }
+
+  public Page<CollectionWithAttempt> searchCollectionsForGuest(List<Long> categoryIds,
+      List<String> keywords, DataPage paging) {
+    // categoryIds 있으면 검증
+    categoryService.areAllCategoriesExist(categoryIds);
+
+    Pageable pageable = createPageable(paging);
+
+    return collectionRepository.searchCollectionsForGuest(categoryIds, keywords, pageable);
   }
 }

--- a/src/main/java/com/interview_master/service/SearchCollectionService.java
+++ b/src/main/java/com/interview_master/service/SearchCollectionService.java
@@ -32,7 +32,7 @@ public class SearchCollectionService {
     Sort sort = createSort(sortOrder);
     Pageable pageable = createPageable(paging, sort);
 
-    return collectionRepository.searchCollections(
+    return collectionRepository.searchCollectionsForAuthUser(
         categoryIds, keywords, maxCorrectRate, pageable, userId);
   }
 }

--- a/src/main/java/com/interview_master/util/PageSortUtils.java
+++ b/src/main/java/com/interview_master/util/PageSortUtils.java
@@ -2,6 +2,7 @@ package com.interview_master.util;
 
 import static com.interview_master.common.constant.Constant.SORT_LATEST;
 import static com.interview_master.common.constant.Constant.SORT_LOWACCURACY;
+import static com.interview_master.common.constant.Constant.SORT_MOSTLIKED;
 
 import com.interview_master.dto.DataPage;
 import com.interview_master.dto.SortOrder;
@@ -15,6 +16,7 @@ public class PageSortUtils {
     return switch (sortOrder) {
       case LATEST -> Sort.by(Sort.Direction.DESC, SORT_LATEST);
       case LOWEST_ACCURACY -> Sort.by(Sort.Direction.ASC, SORT_LOWACCURACY);
+      case MOST_LIKED -> Sort.by(Sort.Direction.DESC, SORT_MOSTLIKED);
     };
   }
 

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -63,6 +63,8 @@ enum SortOrder {
     LATEST
     "정답률 낮은 순"
     LOWEST_ACCURACY
+    "좋아요 많은 순"
+    MOST_LIKED
 }
 
 input DataPage {

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -34,13 +34,20 @@ type Query {
     """로그인한 유저의 정보"""
     me: User
 
-    """컬렉션 검색"""
-    searchCollections(
+    """컬렉션 검색 (로그인한 유저 전용)"""
+    searchCollectionsForAuthUser(
         paging: DataPage,
         sort: SortOrder = LATEST,
         categoryIds: [Int],
         keywords: [String],
         maxCorrectRate: Int
+    ) : CollectionWithAttemptsPaging
+
+    """컬렉션 검색 (비로그인 유저 전용)"""
+    searchCollectionsForGuest(
+        paging: DataPage,
+        categoryIds: [Int],
+        keywords: [String],
     ) : CollectionWithAttemptsPaging
 
     """로그인 유저의 퀴즈에 대한 시도들"""

--- a/src/test/java/com/interview_master/service/SearchCollectionServiceTest.java
+++ b/src/test/java/com/interview_master/service/SearchCollectionServiceTest.java
@@ -28,7 +28,7 @@ class SearchCollectionServiceTest {
   private SearchCollectionService searchCollectionService;
 
   @Test
-  void testSearchCollectionsWithUserId_CategoryIds_Keywords_MaxCorrectRate() {
+  void testSearchCollectionsForAuthUserWithUserId_CategoryIds_Keywords_MaxCorrectRate() {
     // Given
     Long userId = 1L;
     List<Long> categoryIds = Arrays.asList(1L, 2L);
@@ -37,7 +37,7 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LATEST;
 
-    Page<CollectionWithAttempt> result = searchCollectionService.searchCollections(categoryIds,
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForAuthUser(categoryIds,
         keywords, maxCorrectRate, dataPage, sortOrder, userId);
 
     assertNotNull(result);
@@ -80,7 +80,7 @@ class SearchCollectionServiceTest {
   }
 
   @Test
-  void testSearchCollectionsWithoutUserId() {
+  void testSearchCollectionsForAuthUserWithoutUserId() {
     // Given
     Long userId = null;
     List<Long> categoryIds = List.of(1L, 2L);
@@ -89,7 +89,7 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LATEST;
 
-    Page<CollectionWithAttempt> result = searchCollectionService.searchCollections(categoryIds,
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForAuthUser(categoryIds,
         keywords, maxCorrectRate, dataPage, sortOrder, userId);
 
     assertNotNull(result);
@@ -104,7 +104,7 @@ class SearchCollectionServiceTest {
 
   // categoryId가 없는 경우
   @Test
-  void testSearchCollectionsWithNonExistentCategoryId() {
+  void testSearchCollectionsForAuthUserWithNonExistentCategoryId() {
     // Given
     Long userId = 1L;
     List<Long> categoryIds = List.of(9999L); // Assuming this category ID doesn't exist
@@ -113,13 +113,13 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LATEST;
 
-    assertThrows(ApiException.class, () -> searchCollectionService.searchCollections(categoryIds, keywords, maxCorrectRate, dataPage,
+    assertThrows(ApiException.class, () -> searchCollectionService.searchCollectionsForAuthUser(categoryIds, keywords, maxCorrectRate, dataPage,
         sortOrder, userId), "Should throw ApiException for non-existent category");
   }
 
   // 존재하는 categoryId와 categoryId가 섞여 있는 경우
   @Test
-  void testSearchCollectionsWithMixedExistingAndNonExistingCategoryIds() {
+  void testSearchCollectionsForAuthUserWithMixedExistingAndNonExistingCategoryIds() {
     // Given
     Long userId = 1L;
     List<Long> categoryIds = Arrays.asList(1L, 9999L); // Assuming 1L exists and 9999L doesn't
@@ -128,13 +128,13 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LATEST;
 
-    assertThrows(ApiException.class, () -> searchCollectionService.searchCollections(categoryIds, keywords, maxCorrectRate, dataPage,
+    assertThrows(ApiException.class, () -> searchCollectionService.searchCollectionsForAuthUser(categoryIds, keywords, maxCorrectRate, dataPage,
         sortOrder, userId), "Should throw ApiException when at least one category doesn't exist");
   }
 
   // 정답률이 음수인 경우 -> 시도하지 않은 경우들로 반환
   @Test
-  void testSearchCollectionsWithNegativeMaxCorrectRate() {
+  void testSearchCollectionsForAuthUserWithNegativeMaxCorrectRate() {
     // Given
     Long userId = 1L;
     List<Long> categoryIds = Arrays.asList(1L, 2L);
@@ -143,7 +143,7 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LATEST;
 
-    Page<CollectionWithAttempt> result = searchCollectionService.searchCollections(categoryIds,
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForAuthUser(categoryIds,
         keywords, maxCorrectRate, dataPage, sortOrder, userId);
 
     for (CollectionWithAttempt c : result.getContent()) {
@@ -153,7 +153,7 @@ class SearchCollectionServiceTest {
   }
 
   @Test
-  void testSearchCollectionsWithLowestAccuracySorting() {
+  void testSearchCollectionsForAuthUserWithLowestAccuracySorting() {
     // Given
     Long userId = 1L;
     List<Long> categoryIds = Arrays.asList(1L, 2L);
@@ -162,7 +162,7 @@ class SearchCollectionServiceTest {
     DataPage dataPage = new DataPage(0, 10);
     SortOrder sortOrder = SortOrder.LOWEST_ACCURACY;
 
-    Page<CollectionWithAttempt> result = searchCollectionService.searchCollections(categoryIds,
+    Page<CollectionWithAttempt> result = searchCollectionService.searchCollectionsForAuthUser(categoryIds,
         keywords, maxCorrectRate, dataPage, sortOrder, userId);
 
     assertNotNull(result);


### PR DESCRIPTION
## 컬렉션 검색 분리
- 로그인 유무에 따라 검색 쿼리 분리

## 전체 정답률 정보 추가
- 검색 쿼리에 해당 컬렉션의 전체 시도횟수 & 맞은 횟수 ( = 정답률 ) 정보 추가

## 정렬 조건 수정
- 로그인 컬렉션 검색 : 좋아요 많은 순 정렬 조건 추가
- 비로그인 컬렉션 검색 : 무조건 좋아요 많은 순 정렬로 고정