### PR TITLE
fix: 퀴즈가 아직 없는 컬렉션 조회 시, 없는 컬렉션이라고 조회되는 오류 수정

### DIFF
--- a/src/main/java/com/interview_master/infrastructure/CollectionRepository.java
+++ b/src/main/java/com/interview_master/infrastructure/CollectionRepository.java
@@ -26,8 +26,8 @@ public interface CollectionRepository extends Repository<Collection, Long>, Coll
       + "left join fetch c.quizzes q "
       + "where c.id = :id "
       + "and c.isDeleted = false "
-      + "and q.isDeleted = false "
-      + "order by q.updatedAt desc ")
+      + "and (q is null or q.isDeleted = false) "
+      + "order by case when q is not null then q.updatedAt else c.updatedAt end desc")
   Optional<Collection> findByIdWithQuizzes(@Param("id") Long id);
 
   /**


### PR DESCRIPTION
- 쿼리에서 컬렉션과 속한 퀴즈들을 한번에 join으로 가져오는데, 여기서 에러가 발생했음