### PR TITLE
fix: collection 수정 시, JPA 지연 로딩과 Jackson 직렬화 과정에서 발생하는 에러 해결

### DIFF
--- a/src/main/java/com/interview_master/domain/collection/Collection.java
+++ b/src/main/java/com/interview_master/domain/collection/Collection.java
@@ -1,5 +1,6 @@
 package com.interview_master.domain.collection;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.interview_master.common.exception.ApiException;
 import com.interview_master.common.exception.ErrorCode;
 import com.interview_master.domain.Access;
@@ -40,10 +41,12 @@ public class Collection extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "creator_id")
+  @JsonIgnore
   private User creator;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "category_id")
+  @JsonIgnore
   private Category category;
 
   @Enumerated(EnumType.STRING)
@@ -124,10 +127,6 @@ public class Collection extends BaseEntity {
 
   private void setAccess(Access access) {
     this.access = access;
-  }
-
-  private void setCreator(User creator) {
-    this.creator = creator;
   }
 
   private void setCategory(Category category) {

--- a/src/main/java/com/interview_master/service/UpsertCollectionService.java
+++ b/src/main/java/com/interview_master/service/UpsertCollectionService.java
@@ -15,12 +15,14 @@ import com.interview_master.resolver.request.EditCollectionReq;
 import com.interview_master.util.ExtractUserId;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class UpsertCollectionService {
 
   private final CollectionRepository collectionRepository;
@@ -66,7 +68,7 @@ public class UpsertCollectionService {
   public Collection editCollection(Long collectionId, EditCollectionReq editReq) {
     Long userId = ExtractUserId.extractUserIdFromContextHolder();
 
-    Collection collection = collectionRepository.findByIdWithQuizzes(collectionId)
+    Collection collection = collectionRepository.findByIdAndIsDeletedFalse(collectionId)
         .orElseThrow(() -> new ApiException(ErrorCode.COLLECTION_NOT_FOUND));
 
     // 수정 가능한지 검증


### PR DESCRIPTION
- Collection 객체의 category와 creator에 @JsonIgnore 어노테이션 추가해서 해결