### PR TITLE
Hotfix/fix quiz delete consumer

### DIFF
--- a/src/main/java/com/interview_master/infrastructure/UserCollectionAttemptRepository.java
+++ b/src/main/java/com/interview_master/infrastructure/UserCollectionAttemptRepository.java
@@ -31,10 +31,14 @@ public interface UserCollectionAttemptRepository extends Repository<UserCollecti
   @Query("update UserCollectionAttempt ca set ca.user.id = 0L where ca.user.id in :userIds")
   int anonymizedByUserIdIn(@Param("userIds") List<Long> userIds);
 
+  // 완료된 시도에 대해서만 시도 기록을 빼줘야 함
   @Modifying
   @Query("update UserCollectionAttempt ca "
       + "set ca.totalQuizCount = ca.totalQuizCount - 1, "
-      + "ca.correctQuizCount = ca.correctQuizCount - :isCorrect "
+      + "ca.correctQuizCount = CASE "
+      + "    WHEN ca.completedAt is not null THEN ca.correctQuizCount - :isCorrect "
+      + "    ELSE ca.correctQuizCount "
+      + "END "
       + "where ca.id = :ucaId")
   void updateTotalCountAndCorrectCount(@Param("ucaId") Long ucaId,
       @Param("isCorrect") Integer isCorrect);

--- a/src/main/java/com/interview_master/kafka/consumer/QuizDeleteConsumer.java
+++ b/src/main/java/com/interview_master/kafka/consumer/QuizDeleteConsumer.java
@@ -27,13 +27,12 @@ public class QuizDeleteConsumer {
   public void quizDelete(@Payload Long dQuizId) {
     log.info("========== [Consumer] 퀴즈 삭제 비동기 처리 메시지 수행 ==========");
 
-    log.info("========== 퀴즈 삭제로 인한 userCollectionAttempt 모두 수정 ==========");
-
     List<UserQuizAttempt> attemptsByQuizId = uqaRepository.findAllByQuizId(dQuizId);
     attemptsByQuizId.forEach(
         uqa -> ucaRepository.updateTotalCountAndCorrectCount(uqa.getCollectionAttempt().getId(),
             uqa.getIsCorrect() ? 1 : 0));
-    log.info("========== 컬렉션 삭제 비동기 처리 완료 ==========");
+    log.info("========== 퀴즈 삭제로 인한 userCollectionAttempt 모두 수정 ==========");
+    log.info("========== 퀴즈 삭제 비동기 처리 완료 ==========");
   }
 
 }


### PR DESCRIPTION
## 퀴즈 삭제 시 발생한 오류 해결
- 퀴즈 삭제 시, 퀴즈 시도 기록 삭제로 인한 컬렉션 시도 기록을 수정할 때, 아직 진행 중인 컬렉션 시도 기록도 수정해서 correctQuizCount가 음수가 되는 오류 해결